### PR TITLE
Adding an option to specify the cache-expiry for the flickr sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,12 +148,13 @@ your albums and their content.
 ##### init(opts, callback)
 Intialises the API. _opts_ can contain the following options.
 
-* **api_key** - Your flickr API
-* **secret** - Your flickr API secret
-* **user_id** - Your flickr user ID
-* **albums** - The IDs of albums you'd like to restrict displaying. If left
+* **api_key** - (required) Your flickr API
+* **secret** - (required) Your flickr API secret
+* **user_id** - (required) Your flickr user ID
+* **albums** - (optional) The IDs of albums you'd like to restrict displaying. If left
 empty all albums will be shown. If populated, only albums in the array will be
 shown.
+* **cache_expiry** - (optional) The amount of time in milliseconds to keep the in-memory cache of albums from flickr
 
 ##### getAlbumList(callback)
 Get all your albums, or the ones specified in the albums _param_ supplied to

--- a/lib/flickr.js
+++ b/lib/flickr.js
@@ -8,6 +8,7 @@ var FlickrAPI = require('flickrapi')
   , _ = require('lodash')
   , flickr = null
   , permittedAlbums = []
+  , cache_expiry = null
   , opts = {};
 
 var SETS_CACHE_KEY = 'sets'
@@ -29,6 +30,8 @@ exports.init = function (fopts, callback) {
     var e = util.format('Options was missing "%s" key', missingOpt);
     return callback(new Error(e), null);
   }
+
+  cache_expiry = fopts['cache_expiry'] ||  DEFAULT_CACHE_EXPIRY;
 
   // Used to determine if albums should be filtered or not
   permittedAlbums = fopts.albums || permittedAlbums;
@@ -101,7 +104,7 @@ exports.getAlbumList = function (callback) {
       sets = _.map(sets['photosets']['photoset'], convertSet);
       sets = filterAlbums(sets);
 
-      cache.put(SETS_CACHE_KEY, sets, DEFAULT_CACHE_EXPIRY);
+      cache.put(SETS_CACHE_KEY, sets, cache_expiry);
 
       next(null, sets);
     } catch (e) {
@@ -143,7 +146,7 @@ exports.getAlbum = function (albumId, callback) {
           title: set['photoset']['title']
         };
 
-        cache.put(getAlbumCacheKey(), res, DEFAULT_CACHE_EXPIRY);
+        cache.put(getAlbumCacheKey(), res, cache_expiry);
 
         callback(null, res);
       } catch (e) {


### PR DESCRIPTION
I added a small option to specify a cache-expiry on the flickr results.
I might add a few more customizations in the next couple of days and make pull requests for those as well, if you are open to contributions.

Thanks!
